### PR TITLE
Added MaxStepHeight variable

### DIFF
--- a/Plugins/RunebergVRPlugin/Source/Private/RunebergVR_Pawn.cpp
+++ b/Plugins/RunebergVRPlugin/Source/Private/RunebergVR_Pawn.cpp
@@ -115,7 +115,8 @@ void ARunebergVR_Pawn::Tick(float DeltaTime)
 		// Check if we need to float the Pawn over uneven terrain
 		if (GravityVariables.RespondToUnevenTerrain
 			&& bHit && RayHit.GetComponent()->CanCharacterStepUpOn == ECanBeCharacterBase::ECB_Yes
-			&& (RayHit.Distance + GravityVariables.FloorTraceTolerance) < GravityVariables.FloorTraceRange)
+			&& (RayHit.Distance + GravityVariables.FloorTraceTolerance) < GravityVariables.FloorTraceRange
+			&& (GravityVariables.FloorTraceRange - (RayHit.Distance + GravityVariables.FloorTraceTolerance)) < GravityVariables.MaxStepHeight) // Check for MaxStepHeight 
 		{
 			int Steps = FPlatformMath::RoundToInt(GravityVariables.FloorTraceTolerance / StepUpRate);
 			for (int32 i = Steps; i > 1; i--)

--- a/Plugins/RunebergVRPlugin/Source/Public/RunebergVR_Pawn.h
+++ b/Plugins/RunebergVRPlugin/Source/Public/RunebergVR_Pawn.h
@@ -45,6 +45,10 @@ struct FGravityVariables
 	UPROPERTY(EditAnywhere, Category = "VR")
 	float FloorTraceTolerance = 3.f;
 
+	/* Maximum Z offset this VR Pawn will be able to step up */
+	UPROPERTY(EditAnywhere, Category = "VR")
+	float MaxStepHeight = 30.f;
+
 	/** Direction where this VR Pawn will "fall" */
 	UPROPERTY(EditAnywhere, Category = "VR")
 	FVector GravityDirection = FVector(0.f, 0.f, -1.f);


### PR DESCRIPTION
When using gravity and uneven terrain, this variable determines how much Z offset the Player can step up. This is to enable stepping up stairs with a Z offset of 20, for example, but do disallow stepping up a box with a Z offset of 50, for example.